### PR TITLE
Update TrueNAS shutdown REST configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ shell_command:
   truenas_backup: /config/scripts/truenas_backup.sh
 
 rest_command:
-  truenas_shutdown:
-    url: "http://truenas.local/api/v2.0/system/shutdown"
-    method: post
+  shutdown_truenas:
+    url: https://truenas.local/api/v2.0/system/shutdown
+    method: POST
     headers:
-      Authorization: "Bearer <YOUR_API_TOKEN>"
+      # secrets.yaml 內請存放完整字串：  truenas_api: "Bearer XXXXXXXXXXX"
+      Authorization: !secret truenas_api
+      Content-Type: "application/json"
+    payload: >
+      {"reason":"HA automation shutdown","options":{"delay":10}}
+    verify_ssl: true
 ```
 
 3. 編輯 `scripts/truenas_backup.sh` 或透過新增的 Home Assistant Add-on 在 Web UI 中輸入設定值。

--- a/truenas_backup.yaml
+++ b/truenas_backup.yaml
@@ -10,5 +10,5 @@ action:
   - delay: "00:02:00"
     # Adjust as needed, or set STARTUP_DELAY env var in the script
   - service: shell_command.truenas_backup
-  - service: rest_command.truenas_shutdown
+  - service: rest_command.shutdown_truenas
 mode: single


### PR DESCRIPTION
## Summary
- update README to use new shutdown API URL and headers
- rename rest command service call in automation example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dfc2d00d88329a36d682156cee73f