### PR TITLE
Implement logging levels and backup checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ shell_command:
 
 rest_command:
   shutdown_truenas:
-    url: https://truenas.local/api/v2.0/system/shutdown
+    url: https://YOUR_TRUENAS_HOST/api/v2.0/system/shutdown
     method: POST
     headers:
       # secrets.yaml 內請存放完整字串：  truenas_api: "Bearer XXXXXXXXXXX"
@@ -26,9 +26,13 @@ rest_command:
     verify_ssl: true
 ```
 
+將上述 `YOUR_TRUENAS_HOST` 替換為 TrueNAS 主機位址，或透過 `TRUENAS_HOST` 環境變數設定。
+
 3. 編輯 `scripts/truenas_backup.sh` 或透過新增的 Home Assistant Add-on 在 Web UI 中輸入設定值。
 4. 透過 `chmod +x scripts/truenas_backup.sh` 賦予可執行權限（若未使用 add-on）。
 5. 若 TrueNAS 開機時間較長，可透過 `STARTUP_DELAY` 環境變數（秒）調整在 Wake on LAN 後等待多久才開始備份，或於自動化中修改 `delay` 步驟。
+6. 使用 `TRUENAS_HOST` 環境變數指定 TrueNAS 主機位址，預設為 `truenas.local`。
+7. 使用 `LOG_LEVEL` 環境變數調整日誌輸出等級，可選 `debug`、`info`、`warn`、`error` 或 `none`。
 
 自動化預設在每天凌晨 2 點執行，可依需求調整。
 

--- a/addon/config.json
+++ b/addon/config.json
@@ -7,19 +7,25 @@
   "startup": "once",
   "boot": "auto",
   "options": {
-    "smb_share": "//truenas.local/backup",
+    "truenas_host": "truenas.local",
+    "smb_share": "",
     "mount_point": "/tmp/truenas_backup_mount",
     "username": "youruser",
     "password": "yourpassword",
     "local_path": "/path/to/local/backup",
-    "startup_delay": 120
+    "startup_delay": 120,
+    "log_level": "info",
+    "verify_shutdown": false
   },
   "schema": {
+    "truenas_host": "str",
     "smb_share": "str",
     "mount_point": "str",
     "username": "str",
     "password": "str",
     "local_path": "str",
-    "startup_delay": "int"
+    "startup_delay": "int",
+    "log_level": "str",
+    "verify_shutdown": "bool"
   }
 }

--- a/addon/run.sh
+++ b/addon/run.sh
@@ -2,12 +2,15 @@
 # shellcheck shell=bash
 set -e
 CONFIG_PATH=/data/options.json
-SMB_SHARE=$(jq -r '.smb_share' "$CONFIG_PATH")
+TRUENAS_HOST=$(jq -r '.truenas_host // ""' "$CONFIG_PATH")
+SMB_SHARE=$(jq -r '.smb_share // ""' "$CONFIG_PATH")
 MOUNT_POINT=$(jq -r '.mount_point' "$CONFIG_PATH")
 USERNAME=$(jq -r '.username' "$CONFIG_PATH")
 PASSWORD=$(jq -r '.password' "$CONFIG_PATH")
 LOCAL_BACKUP_PATH=$(jq -r '.local_path' "$CONFIG_PATH")
 STARTUP_DELAY=$(jq -r '.startup_delay' "$CONFIG_PATH")
-export SMB_SHARE MOUNT_POINT USERNAME PASSWORD LOCAL_BACKUP_PATH STARTUP_DELAY
+LOG_LEVEL=$(jq -r '.log_level // "info"' "$CONFIG_PATH")
+VERIFY_SHUTDOWN=$(jq -r '.verify_shutdown // false' "$CONFIG_PATH")
+export TRUENAS_HOST SMB_SHARE MOUNT_POINT USERNAME PASSWORD LOCAL_BACKUP_PATH STARTUP_DELAY LOG_LEVEL VERIFY_SHUTDOWN
 
 /usr/local/bin/truenas_backup.sh

--- a/addon/truenas_backup.sh
+++ b/addon/truenas_backup.sh
@@ -5,28 +5,116 @@
 
 set -e
 
-SMB_SHARE="${SMB_SHARE:-//truenas.local/backup}"        # SMB share path
+# Logging configuration
+LOG_LEVEL="${LOG_LEVEL:-info}"
+
+log_level_num() {
+  case "$1" in
+    none) echo 0 ;;
+    error) echo 1 ;;
+    warn) echo 2 ;;
+    info) echo 3 ;;
+    debug) echo 4 ;;
+    *) echo 3 ;;
+  esac
+}
+
+CURRENT_LEVEL=$(log_level_num "$LOG_LEVEL")
+log() {
+  local level="$1"
+  shift
+  local level_num
+  level_num=$(log_level_num "$level")
+  if [ "$CURRENT_LEVEL" -ge "$level_num" ] && [ "$CURRENT_LEVEL" -ne 0 ]; then
+    printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*"
+  fi
+}
+
+TRUENAS_HOST="${TRUENAS_HOST:-}"
+SMB_SHARE="${SMB_SHARE:-}"
 MOUNT_POINT="${MOUNT_POINT:-/tmp/truenas_backup_mount}"  # Temporary mount point
 USERNAME="${USERNAME:-youruser}"                         # SMB username
 PASSWORD="${PASSWORD:-yourpassword}"                     # SMB password
 # Local path to store backups
 LOCAL_BACKUP_PATH="${LOCAL_BACKUP_PATH:-/path/to/local/backup}"
 STARTUP_DELAY="${STARTUP_DELAY:-120}"
+VERIFY_SHUTDOWN="${VERIFY_SHUTDOWN:-0}"
+
+if [ -z "$TRUENAS_HOST" ] && [ -n "$SMB_SHARE" ]; then
+  TRUENAS_HOST=$(echo "$SMB_SHARE" | sed -e 's|^//||' -e 's|/.*$||')
+fi
+TRUENAS_HOST="${TRUENAS_HOST:-truenas.local}"
+SMB_SHARE="${SMB_SHARE:-//${TRUENAS_HOST}/backup}"
+
+
+# Check if TrueNAS is online
+log info "Checking if TrueNAS ($TRUENAS_HOST) is online"
+if ping -c 1 "$TRUENAS_HOST" >/dev/null 2>&1; then
+  log info "TrueNAS is reachable"
+else
+  log error "TrueNAS is not reachable"
+  exit 1
+fi
 
 if [ "$STARTUP_DELAY" -gt 0 ]; then
-  echo "Waiting $STARTUP_DELAY seconds for TrueNAS to boot..."
+  log debug "Waiting $STARTUP_DELAY seconds for TrueNAS to boot"
   sleep "$STARTUP_DELAY"
 fi
 
+log debug "Creating mount point $MOUNT_POINT"
 mkdir -p "$MOUNT_POINT"
 
 if ! mountpoint -q "$MOUNT_POINT"; then
-  mount -t cifs "$SMB_SHARE" "$MOUNT_POINT" \
-    -o username="$USERNAME",password="$PASSWORD",rw
+  log info "Mounting SMB share $SMB_SHARE"
+  if mount -t cifs "$SMB_SHARE" "$MOUNT_POINT" -o username="$USERNAME",password="$PASSWORD",rw; then
+    log info "SMB mount successful"
+  else
+    log error "Failed to mount SMB share"
+    exit 1
+  fi
+else
+  log debug "Mount point already mounted"
 fi
 
-# Example rsync command copying from the SMB share to a local path.
-# Destination controlled via the LOCAL_BACKUP_PATH variable.
-rsync -av "$MOUNT_POINT/" "$LOCAL_BACKUP_PATH/"
+# Test read/write access
+if touch "$MOUNT_POINT/.rw_test" && rm "$MOUNT_POINT/.rw_test"; then
+  log info "Read/write test on SMB share successful"
+else
+  log error "Read/write test on SMB share failed"
+  umount "$MOUNT_POINT"
+  exit 1
+fi
+
+# Run rsync to copy data from the SMB share
+log info "Starting rsync backup"
+if rsync -av "$MOUNT_POINT/" "$LOCAL_BACKUP_PATH/"; then
+  log info "rsync completed successfully"
+else
+  log error "rsync encountered errors"
+  umount "$MOUNT_POINT"
+  exit 1
+fi
+
+# Verify that files were copied
+remote_count=$(find "$MOUNT_POINT" -type f | wc -l)
+local_count=$(find "$LOCAL_BACKUP_PATH" -type f | wc -l)
+if [ "$local_count" -ge "$remote_count" ]; then
+  log info "Backup verification succeeded ($local_count files)"
+else
+  log warn "Backup verification mismatch: $remote_count files on source, $local_count on destination"
+fi
 
 umount "$MOUNT_POINT"
+
+if [ "$VERIFY_SHUTDOWN" -eq 1 ]; then
+  log info "Verifying TrueNAS shutdown"
+  for _ in {1..10}; do
+    if ping -c 1 "$TRUENAS_HOST" >/dev/null 2>&1; then
+      log debug "TrueNAS still online, waiting..."
+      sleep 10
+    else
+      log info "TrueNAS is offline"
+      break
+    fi
+  done
+fi

--- a/scripts/truenas_backup.sh
+++ b/scripts/truenas_backup.sh
@@ -5,28 +5,116 @@
 
 set -e
 
-SMB_SHARE="${SMB_SHARE:-//truenas.local/backup}"        # SMB share path
+# Logging configuration
+LOG_LEVEL="${LOG_LEVEL:-info}"
+
+log_level_num() {
+  case "$1" in
+    none) echo 0 ;;
+    error) echo 1 ;;
+    warn) echo 2 ;;
+    info) echo 3 ;;
+    debug) echo 4 ;;
+    *) echo 3 ;;
+  esac
+}
+
+CURRENT_LEVEL=$(log_level_num "$LOG_LEVEL")
+log() {
+  local level="$1"
+  shift
+  local level_num
+  level_num=$(log_level_num "$level")
+  if [ "$CURRENT_LEVEL" -ge "$level_num" ] && [ "$CURRENT_LEVEL" -ne 0 ]; then
+    printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*"
+  fi
+}
+
+TRUENAS_HOST="${TRUENAS_HOST:-}"
+SMB_SHARE="${SMB_SHARE:-}"
 MOUNT_POINT="${MOUNT_POINT:-/tmp/truenas_backup_mount}"  # Temporary mount point
 USERNAME="${USERNAME:-youruser}"                         # SMB username
 PASSWORD="${PASSWORD:-yourpassword}"                     # SMB password
 # Local path to store backups
 LOCAL_BACKUP_PATH="${LOCAL_BACKUP_PATH:-/path/to/local/backup}"
 STARTUP_DELAY="${STARTUP_DELAY:-120}"
+VERIFY_SHUTDOWN="${VERIFY_SHUTDOWN:-0}"
+
+if [ -z "$TRUENAS_HOST" ] && [ -n "$SMB_SHARE" ]; then
+  TRUENAS_HOST=$(echo "$SMB_SHARE" | sed -e 's|^//||' -e 's|/.*$||')
+fi
+TRUENAS_HOST="${TRUENAS_HOST:-truenas.local}"
+SMB_SHARE="${SMB_SHARE:-//${TRUENAS_HOST}/backup}"
+
+
+# Check if TrueNAS is online
+log info "Checking if TrueNAS ($TRUENAS_HOST) is online"
+if ping -c 1 "$TRUENAS_HOST" >/dev/null 2>&1; then
+  log info "TrueNAS is reachable"
+else
+  log error "TrueNAS is not reachable"
+  exit 1
+fi
 
 if [ "$STARTUP_DELAY" -gt 0 ]; then
-  echo "Waiting $STARTUP_DELAY seconds for TrueNAS to boot..."
+  log debug "Waiting $STARTUP_DELAY seconds for TrueNAS to boot"
   sleep "$STARTUP_DELAY"
 fi
 
+log debug "Creating mount point $MOUNT_POINT"
 mkdir -p "$MOUNT_POINT"
 
 if ! mountpoint -q "$MOUNT_POINT"; then
-  mount -t cifs "$SMB_SHARE" "$MOUNT_POINT" \
-    -o username="$USERNAME",password="$PASSWORD",rw
+  log info "Mounting SMB share $SMB_SHARE"
+  if mount -t cifs "$SMB_SHARE" "$MOUNT_POINT" -o username="$USERNAME",password="$PASSWORD",rw; then
+    log info "SMB mount successful"
+  else
+    log error "Failed to mount SMB share"
+    exit 1
+  fi
+else
+  log debug "Mount point already mounted"
 fi
 
-# Example rsync command copying from the SMB share to a local path.
-# Destination controlled via the LOCAL_BACKUP_PATH variable.
-rsync -av "$MOUNT_POINT/" "$LOCAL_BACKUP_PATH/"
+# Test read/write access
+if touch "$MOUNT_POINT/.rw_test" && rm "$MOUNT_POINT/.rw_test"; then
+  log info "Read/write test on SMB share successful"
+else
+  log error "Read/write test on SMB share failed"
+  umount "$MOUNT_POINT"
+  exit 1
+fi
+
+# Run rsync to copy data from the SMB share
+log info "Starting rsync backup"
+if rsync -av "$MOUNT_POINT/" "$LOCAL_BACKUP_PATH/"; then
+  log info "rsync completed successfully"
+else
+  log error "rsync encountered errors"
+  umount "$MOUNT_POINT"
+  exit 1
+fi
+
+# Verify that files were copied
+remote_count=$(find "$MOUNT_POINT" -type f | wc -l)
+local_count=$(find "$LOCAL_BACKUP_PATH" -type f | wc -l)
+if [ "$local_count" -ge "$remote_count" ]; then
+  log info "Backup verification succeeded ($local_count files)"
+else
+  log warn "Backup verification mismatch: $remote_count files on source, $local_count on destination"
+fi
 
 umount "$MOUNT_POINT"
+
+if [ "$VERIFY_SHUTDOWN" -eq 1 ]; then
+  log info "Verifying TrueNAS shutdown"
+  for _ in {1..10}; do
+    if ping -c 1 "$TRUENAS_HOST" >/dev/null 2>&1; then
+      log debug "TrueNAS still online, waiting..."
+      sleep 10
+    else
+      log info "TrueNAS is offline"
+      break
+    fi
+  done
+fi


### PR DESCRIPTION
## Summary
- support configurable log levels and verification options
- implement SMB mount, rsync and shutdown checks with logging
- expose `log_level` and `verify_shutdown` options in the add-on configuration
- document how to set `LOG_LEVEL`
- allow overriding the TrueNAS host via `TRUENAS_HOST` everywhere

## Testing
- `bash -n scripts/truenas_backup.sh`
- `bash -n addon/truenas_backup.sh`
- `bash -n addon/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_686dfe77dcf48329b3b17289034c8342