### PR TITLE
Add changelog and dropdown config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 1.2.0
 - 新增 log level 下拉選單與時間選擇器
 - 新增根目錄 CHANGELOG 記錄

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![GitHub release](https://img.shields.io/github/v/release/marttrach/HA_Truenas_Auto_Backup)](https://github.com/marttrach/HA_Truenas_Auto_Backup/releases/latest)
 
+完整更新記錄請參考 [CHANGELOG](CHANGELOG.md)。
+
 提供 Home Assistant 自動任務範例，透過 Wake on LAN 啟動 TrueNAS，
 在備份完成後使用 REST API 關閉系統。
 

--- a/truenas_backup/README.md
+++ b/truenas_backup/README.md
@@ -9,6 +9,7 @@
 `startup_delay` 參數可以指定在發送 Wake on LAN 後等待多少秒才開始備份，以符合 TrueNAS 開機所需時間。
 `wol_mac`、`wol_broadcast` 與 `wol_port` 分別對應 Wake on LAN 的目標 MAC 位址、廣播位置以及連接埠，
 `trigger_time` 則用來指定每天何時執行備份，add-on 啟動後會依此時間自動執行。
+自 1.2.0 起，`log_level` 於設定頁面提供下拉選單，`trigger_time` 則使用時間選擇器，設定更加直覺。
 
 ## Ingress 與文件
 本 add-on 不包含額外的 Web 介面，但可以透過 Ingress 檢視此說明文件。進入 Add-on 詳細畫面後，點選上方的 `Documentation` 按鈕即可開啟。

--- a/truenas_backup/config.json
+++ b/truenas_backup/config.json
@@ -2,7 +2,7 @@
   "name": "TrueNAS Backup",
   "slug": "truenas_backup",
   "description": "Backup TrueNAS share via SMB.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "arch": [
     "amd64",
     "aarch64",
@@ -37,13 +37,13 @@
     "password": "str",
     "local_path": "str",
     "startup_delay": "int",
-    "log_level": "str",
+    "log_level": "list(debug|info|warn|error|none)",
     "verify_shutdown": "bool",
     "watchdog": "bool",
     "wol_mac": "str",
     "wol_broadcast": "str",
     "wol_port": "int",
-    "trigger_time": "str"
+    "trigger_time": "time"
   },
   "url": "https://github.com/marttrach/HA_Truenas_Auto_Backup",
   "documentation": "https://github.com/marttrach/HA_Truenas_Auto_Backup/blob/main/truenas_backup/README.md"


### PR DESCRIPTION
## Summary
- add top-level CHANGELOG
- update addon version to 1.2.0
- use dropdown for log level and time picker for trigger_time
- mention changelog and new UI options in docs

## Testing
- `jq empty truenas_backup/config.json`

------
https://chatgpt.com/codex/tasks/task_e_686e78876be883299795f464eb790efb