### PR TITLE
Add samba-client to Dockerfile

### DIFF
--- a/truenas_backup/Dockerfile
+++ b/truenas_backup/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20
-RUN apk add --no-cache bash coreutils jq cifs-utils rsync python3
+RUN apk add --no-cache bash coreutils jq cifs-utils rsync python3 samba-client
 COPY run.sh /run.sh
 COPY truenas_backup.sh /usr/local/bin/truenas_backup.sh
 RUN chmod +x /run.sh /usr/local/bin/truenas_backup.sh


### PR DESCRIPTION
## Summary
- install `samba-client` to provide `smbget` in the addon image

## Testing
- `docker build -t test-image truenas_backup` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0d7f3af483298a6b91dc8a6ecaf6