### PR TITLE
Automate release creation on tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
-name: Build & Push GHCR images
+name: Build & Release
 
 on:
   push:
     branches: [main]
+    tags: ['v*.*.*']
     paths-ignore:
       - '**.md'
   workflow_dispatch:
@@ -11,42 +12,51 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     strategy:
       matrix:
         arch: [amd64, armv7, armhf, aarch64, i386]
         include:
-          - arch: amd64     # 64-bit x86
+          - arch: amd64
             platform: linux/amd64
-          - arch: armv7     # Raspberry Pi 32-bit
+          - arch: armv7
             platform: linux/arm/v7
-          - arch: armhf     # old RPi/BeagleBone
+          - arch: armhf
             platform: linux/arm/v6
-          - arch: aarch64   # 64-bit ARM
+          - arch: aarch64
             platform: linux/arm64
           - arch: i386
             platform: linux/386
 
     steps:
-      - name: 取出程式碼
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: 安裝 QEMU（跨架構模擬）
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: 啟用 buildx
+      - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 登入 GHCR
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 建置並推送單架構映像
+      - name: Extract version
+        id: vars
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(jq -r .version truenas_backup/config.json)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image
         uses: docker/build-push-action@v5
         with:
           context: ./truenas_backup
@@ -54,5 +64,22 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/truenas_backup-${{ matrix.arch }}:latest
+            ghcr.io/${{ github.repository_owner }}/truenas_backup-${{ matrix.arch }}:${{ steps.vars.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/truenas_backup-${{ matrix.arch }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/truenas_backup-${{ matrix.arch }}:1.0.0
+
+      - name: Generate release notes
+        if: startsWith(github.ref, 'refs/tags/')
+        id: notes
+        run: |
+          ver=${{ steps.vars.outputs.version }}
+          awk "/## ${ver}/{flag=1;next}/##/{flag=0}flag" CHANGELOG.md > release_notes.md
+          cat release_notes.md
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.version }}
+          name: ${{ steps.vars.outputs.version }}
+          body_path: release_notes.md
+


### PR DESCRIPTION
## Summary
- enable release creation when pushing version tags
- reuse version from tag or addon config
- include CHANGELOG snippet in release notes

## Testing
- `yamllint .github/workflows/build.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc6b00db483299b1f0aad2ad6797e