### PR TITLE
Add startup log for backup service and ping status

### DIFF
--- a/truenas_backup/run.sh
+++ b/truenas_backup/run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # shellcheck shell=bash
 set -e
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
 CONFIG_PATH=/data/options.json
 TRUENAS_HOST=$(jq -r '.truenas_host // ""' "$CONFIG_PATH")
 SMB_SHARE=$(jq -r '.smb_share // ""' "$CONFIG_PATH")
@@ -16,6 +20,12 @@ WOL_MAC=$(jq -r '.wol_mac // ""' "$CONFIG_PATH")
 WOL_BROADCAST=$(jq -r '.wol_broadcast // "255.255.255.255"' "$CONFIG_PATH")
 WOL_PORT=$(jq -r '.wol_port // 9' "$CONFIG_PATH")
 TRIGGER_TIME=$(jq -r '.trigger_time // "02:00:00"' "$CONFIG_PATH")
+log "TrueNAS backup service starting"
+log "Configuration loaded. Trigger time set to $TRIGGER_TIME"
+if [ ! -x /usr/local/bin/truenas_backup.sh ]; then
+  log "Error: /usr/local/bin/truenas_backup.sh not found"
+  exit 1
+fi
 export TRUENAS_HOST SMB_SHARE MOUNT_POINT USERNAME PASSWORD LOCAL_BACKUP_PATH STARTUP_DELAY LOG_LEVEL VERIFY_SHUTDOWN WATCHDOG WOL_MAC WOL_BROADCAST WOL_PORT TRIGGER_TIME
 
 while true; do
@@ -25,12 +35,22 @@ while true; do
     target=$(date -d "tomorrow $TRIGGER_TIME" +%s)
   fi
   end=$((target - now))
+  log "Next backup scheduled at $(date -d @"$target" '+%Y-%m-%d %H:%M:%S')"
   for ((i=0; i<end; i++)); do
+    if (( i % 60 == 0 )); then
+      if ping -c 1 -W 1 "$TRUENAS_HOST" >/dev/null 2>&1; then
+        log "TrueNAS $TRUENAS_HOST reachable"
+      else
+        log "Warning: TrueNAS $TRUENAS_HOST unreachable"
+      fi
+    fi
     if read -r -t 1 cmd; then
       if [ "$cmd" = "run" ]; then
+        log "Manual run triggered"
         /usr/local/bin/truenas_backup.sh
       fi
     fi
   done
+  log "Starting scheduled backup"
   /usr/local/bin/truenas_backup.sh
 done


### PR DESCRIPTION
## Summary
- log when the service starts
- check TrueNAS host reachability every minute

## Testing
- `bash -n truenas_backup/run.sh`
- `bash -n scripts/truenas_backup.sh`
- `bash -n truenas_backup/truenas_backup.sh`


------
https://chatgpt.com/codex/tasks/task_e_686fcce9fb888329a6c0c0d83c5ea671